### PR TITLE
feat: add CLI option registry and default help

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # PrimeScope
+
+## CLI запуск (script/processor.py)
+Єдиний вхід для керування опціями PrimeScope.
+Опції зберігаються у `src/app/options/options.py` через функцію `get_options()`.
+За замовчуванням запуск без аргументів викликає опцію `help`.
+На цьому етапі доступна лише опція `help`.
+
+### Приклади
+```
+# показати довідку
+python script/processor.py
+
+# те саме явно
+python script/processor.py help
+
+# довідка по конкретній опції (демо з help)
+python script/processor.py help help
+```
+
+### Коди завершення
+- 0 - успіх
+- 2 - невідома опція/некоректне використання
+- 1 - фатальна помилка
+
+### Розширення
+Щоб додати нову опцію, додайте запис у `get_options()` з полями `about`, `usage` та `handler`.
+Опції не прописуються у `script/processor.py`, тільки в `options.py`.

--- a/script/processor.py
+++ b/script/processor.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+# Ensure src directory is on the Python path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from app.options.options import get_options
+
+
+def main(argv: List[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    options = get_options()
+
+    if not argv:
+        return options["help"]["handler"]([])
+
+    name, args = argv[0], argv[1:]
+    if name in options:
+        try:
+            handler = options[name]["handler"]
+            return handler(args)
+        except Exception:
+            return 1
+    print(f"Невідома опція: {name}")
+    options["help"]["handler"]([])
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/options/options.py
+++ b/src/app/options/options.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+
+# Global registry for option specifications
+_OPTIONS: Dict[str, Dict[str, object]] = {}
+
+
+def _print_general_help() -> None:
+    print("PrimeScope CLI")
+    print("Доступні опції")
+    for name, spec in _OPTIONS.items():
+        print(f"  {name} - {spec['about']}")
+    print("Приклади")
+    print("  python script/processor.py")
+    print("  python script/processor.py help")
+    print("  python script/processor.py help help")
+
+
+def _help_handler(args: List[str]) -> int:
+    if not args:
+        _print_general_help()
+        return 0
+    name = args[0]
+    if name in _OPTIONS:
+        spec = _OPTIONS[name]
+        print(f"{name} - {spec['about']}")
+        print(f"Використання: {spec['usage']}")
+        return 0
+    print(f"Невідома опція для help: {name}")
+    _print_general_help()
+    return 2
+
+
+def get_options() -> Dict[str, Dict[str, object]]:
+    """Return registry of CLI options."""
+    if "help" not in _OPTIONS:
+        _OPTIONS["help"] = {
+            "about": "Показує список доступних опцій та приклади використання",
+            "usage": "python script/processor.py help [<option>]",
+            "handler": _help_handler,
+        }
+    return _OPTIONS


### PR DESCRIPTION
## Summary
- add central CLI option registry with built-in help handler
- implement script/processor.py router that delegates to options
- document CLI usage, exit codes, and extension guidelines

## Testing
- `python script/processor.py; printf 'exit=%d\n' $?`
- `python script/processor.py help; printf 'exit=%d\n' $?`
- `python script/processor.py help help; printf 'exit=%d\n' $?`
- `python script/processor.py foo; printf 'exit=%d\n' $?`


------
https://chatgpt.com/codex/tasks/task_e_68adf551c5288331b9ef2e00f4f0fdc3