### PR TITLE
Add run pipeline option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Єдиний вхід для керування опціями PrimeScope.
 Опції зберігаються у `src/app/options/options.py` через функцію `get_options()`.
 За замовчуванням запуск без аргументів викликає опцію `help`.
-На цьому етапі доступна лише опція `help`.
+Опції `help` та `run` демонструють підхід до розширення CLI.
 
 ### Приклади
 ```
@@ -26,3 +26,39 @@ python scripts/processor.py help help
 ### Розширення
 Щоб додати нову опцію, додайте запис у `get_options()` з полями `about`, `usage` та `handler`.
 Опції не прописуються у `scripts/processor.py`, тільки в `options.py`.
+
+## CLI: опція run
+
+Опція `run` запускає повний прод-цикл обробки даних. Кроки за замовчуванням:
+`collect → normalize → dedupe → verify → report`.
+
+Опис циклів зберігається у `src/app/pipeline/flows.py`, а логіка запуску
+розташована у `src/app/pipeline/runner.py`. Реєстр опцій знаходиться у
+`src/app/options/options.py`.
+
+### Приклади
+```
+# показати довідку
+python scripts/processor.py
+python scripts/processor.py help
+
+# запустити повний цикл
+python scripts/processor.py run
+
+# обмежити діапазон кроків
+python scripts/processor.py run --from normalize --to report
+
+# пропустити кроки
+python scripts/processor.py run --skip normalize,dedupe
+
+# сухий прогін
+python scripts/processor.py run --dry-run
+
+# очистити інтерім перед запуском
+python scripts/processor.py run --clean-first --yes
+```
+
+### Коди завершення
+- 0 - успіх
+- 2 - некоректні аргументи або відсутнє підтвердження для руйнівних дій
+- 1 - фатальна помилка

--- a/src/app/options/options.py
+++ b/src/app/options/options.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, List
+import argparse
+from typing import Dict, List
 
 
 # Global registry for option specifications
@@ -33,6 +34,38 @@ def _help_handler(args: List[str]) -> int:
     return 2
 
 
+class _RunArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:  # type: ignore[override]
+        raise ValueError(message)
+
+
+def _run_handler(args: List[str]) -> int:
+    parser = _RunArgumentParser(prog="run")
+    parser.add_argument("--from", dest="from_step")
+    parser.add_argument("--to", dest="to_step")
+    parser.add_argument("--skip")
+    parser.add_argument("--clean-first", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+    try:
+        ns = parser.parse_args(args)
+    except ValueError:
+        print("Некоректні аргументи для run")
+        print(f"Використання: {_OPTIONS['run']['usage']}")
+        return 2
+    skip = ns.skip.split(",") if ns.skip else []
+    from app.pipeline import flows, runner
+    return runner.run_flow(
+        flow=flows.DEFAULT_FLOW,
+        from_step=ns.from_step,
+        to_step=ns.to_step,
+        skip=skip,
+        clean_first=ns.clean_first,
+        dry_run=ns.dry_run,
+        yes=ns.yes,
+    )
+
+
 def get_options() -> Dict[str, Dict[str, object]]:
     """Return registry of CLI options."""
     if "help" not in _OPTIONS:
@@ -40,5 +73,11 @@ def get_options() -> Dict[str, Dict[str, object]]:
             "about": "Показує список доступних опцій та приклади використання",
             "usage": "python scripts/processor.py help [<option>]",
             "handler": _help_handler,
+        }
+    if "run" not in _OPTIONS:
+        _OPTIONS["run"] = {
+            "about": "Запустити повний цикл обробки: collect → normalize → dedupe → verify → report",
+            "usage": "python scripts/processor.py run [--from STEP] [--to STEP] [--skip STEP[,STEP]] [--clean-first] [--dry-run] [--yes]",
+            "handler": _run_handler,
         }
     return _OPTIONS

--- a/src/app/pipeline/flows.py
+++ b/src/app/pipeline/flows.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Definitions of processing flows."""
+
+STEPS = ["collect", "normalize", "dedupe", "verify", "report"]
+
+DEFAULT_FLOW = STEPS
+
+# Placeholder for future custom flows
+EXAMPLE_FLOW = STEPS
+

--- a/src/app/pipeline/runner.py
+++ b/src/app/pipeline/runner.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+import importlib
+import shutil
+from typing import List, Optional
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INTERIM_DIR = ROOT / "data" / "interim"
+
+
+def _select_steps(flow: List[str], from_step: Optional[str], to_step: Optional[str], skip: List[str]) -> Optional[List[str]]:
+    try:
+        start = flow.index(from_step) if from_step else 0
+    except ValueError:
+        print(f"Невідомий крок для --from: {from_step}")
+        return None
+    try:
+        end = flow.index(to_step) + 1 if to_step else len(flow)
+    except ValueError:
+        print(f"Невідомий крок для --to: {to_step}")
+        return None
+    steps = flow[start:end]
+    return [s for s in steps if s not in skip]
+
+
+def _load_step_module(step: str):
+    for mod_name in (f"app.processors.{step}", f"app.collectors.{step}"):
+        try:
+            return importlib.import_module(mod_name)
+        except ModuleNotFoundError:
+            continue
+    return None
+
+
+def run_flow(*, flow: List[str], from_step: Optional[str], to_step: Optional[str], skip: List[str], clean_first: bool, dry_run: bool, yes: bool) -> int:
+    steps = _select_steps(flow, from_step, to_step, skip)
+    if steps is None:
+        return 2
+    if clean_first:
+        if not yes:
+            print("--clean-first потребує підтвердження --yes")
+            return 2
+        if dry_run:
+            print("[dry-run] Очистити дані в data/interim")
+        else:
+            if INTERIM_DIR.exists():
+                for item in INTERIM_DIR.iterdir():
+                    if item.is_file():
+                        item.unlink()
+                    else:
+                        shutil.rmtree(item)
+            print("Очищено data/interim")
+    if dry_run:
+        print("План виконання:", ", ".join(steps))
+        return 0
+    for step in steps:
+        module = _load_step_module(step)
+        if module and hasattr(module, "main"):
+            try:
+                code = module.main()
+            except Exception as exc:
+                print(f"Помилка кроку {step}: {exc}")
+                return 1
+            if code != 0:
+                print(f"Крок {step} завершився з кодом {code}")
+                return 1
+            continue
+        print(f"Немає реалізації для кроку {step}")
+    return 0


### PR DESCRIPTION
## Summary
- add pipeline flow definitions and runner
- support new `run` CLI option for executing processing flows
- document `run` usage and options in README

## Testing
- `python scripts/processor.py`
- `python scripts/processor.py run`
- `python scripts/processor.py run --from normalize --to report`
- `python scripts/processor.py run --skip normalize,dedupe`
- `python scripts/processor.py run --dry-run`
- `python - <<'PY'
import subprocess
res = subprocess.run(['python','scripts/processor.py','run','--clean-first'])
print('returncode', res.returncode)
PY`
- `python - <<'PY'
import subprocess
res = subprocess.run(['python','scripts/processor.py','run','--clean-first','--yes','--dry-run'])
print('returncode', res.returncode)
PY`
- `python - <<'PY'
import subprocess
res = subprocess.run(['python','scripts/processor.py','run','--unknown'])
print('returncode', res.returncode)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adf96414448331b514e6bd74f52224