### PR TITLE
Add basic pipeline logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ python scripts/processor.py           # help
 python scripts/processor.py run       # повний цикл з новими кроками
 ```
 
+## Логування
+За замовчуванням повідомлення рівня INFO виводяться у консоль та у файл `logs/pscope.log`.
+
+Приклад виводу під час `run`:
+```
+▶ step=collect status=start
+✓ step=collect status=done duration=0.241s
+▶ step=validate status=start
+✓ step=validate status=done duration=0.102s
+...
+run: done
+```
+

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -9,9 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from app.options.options import get_options
+from app.utils.logging import setup_logging
 
 
 def main(argv: List[str] | None = None) -> int:
+    setup_logging()
     if argv is None:
         argv = sys.argv[1:]
 

--- a/src/app/ingest/collect.py
+++ b/src/app/ingest/collect.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the collect step."""
-    print("[collect] плейсхолдер")
     return 0
 

--- a/src/app/options/options.py
+++ b/src/app/options/options.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from app.utils.logging import get_logger
+
 
 # Global registry for option specifications
 _OPTIONS: Dict[str, Dict[str, object]] = {}
+
+logger = get_logger(__name__)
 
 
 def _print_general_help() -> None:
@@ -35,13 +39,16 @@ def _help_handler(args: List[str]) -> int:
 
 def _run_handler(args: List[str]) -> int:
     """Handler for the run option."""
+    logger.info("run: start")
     kwargs = {}
     for arg in args:
         if arg.startswith("--") and "=" in arg:
             key, value = arg[2:].split("=", 1)
             kwargs[key.replace("-", "_")] = value
     from app.pipeline import flows, runner
-    return runner.run_flow(flow=flows.DEFAULT_FLOW, **kwargs)
+    code = runner.run_flow(flow=flows.DEFAULT_FLOW, **kwargs)
+    logger.info("run: done")
+    return code
 
 
 def get_options() -> Dict[str, Dict[str, object]]:

--- a/src/app/pipeline/runner.py
+++ b/src/app/pipeline/runner.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import importlib
+import time
 from typing import Dict
+
+from app.utils.logging import get_logger
 
 
 MODULES: Dict[str, str] = {
@@ -16,12 +19,26 @@ MODULES: Dict[str, str] = {
 }
 
 
+logger = get_logger(__name__)
+
+
 def run_flow(*, flow: list[str], **kwargs) -> int:
     """Execute the given flow of pipeline steps."""
     for step in flow:
-        module = importlib.import_module(MODULES[step])
-        code = module.run(**kwargs)
-        if code != 0:
-            return code
+        start = time.perf_counter()
+        logger.info("▶ step=%s status=start", step)
+        try:
+            module = importlib.import_module(MODULES[step])
+            code = module.run(**kwargs)
+            duration = time.perf_counter() - start
+            if code == 0:
+                logger.info("✓ step=%s status=done duration=%.3fs", step, duration)
+            else:
+                logger.info("✖ step=%s status=error duration=%.3fs", step, duration)
+                return code
+        except Exception:
+            duration = time.perf_counter() - start
+            logger.info("✖ step=%s status=error duration=%.3fs", step, duration)
+            return 1
     return 0
 

--- a/src/app/processors/normalize.py
+++ b/src/app/processors/normalize.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the normalize step."""
-    print("[normalize] плейсхолдер")
     return 0
 

--- a/src/app/quality/checks.py
+++ b/src/app/quality/checks.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the checks step."""
-    print("[checks] плейсхолдер")
     return 0
 

--- a/src/app/reporters/report.py
+++ b/src/app/reporters/report.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the report step."""
-    print("[report] плейсхолдер")
     return 0
 

--- a/src/app/stage/interim.py
+++ b/src/app/stage/interim.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the interim step."""
-    print("[interim] плейсхолдер")
     return 0
 

--- a/src/app/utils/logging.py
+++ b/src/app/utils/logging.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def setup_logging(level: str = "INFO", log_file: str = "logs/pscope.log") -> None:
+    path = Path(log_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    fmt = "[%(asctime)s] %(levelname)s: %(message)s"
+    formatter = logging.Formatter(fmt)
+
+    root.handlers.clear()
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    root.addHandler(console)
+
+    file_handler = logging.FileHandler(path, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -5,6 +5,5 @@ from __future__ import annotations
 
 def run(**kwargs) -> int:
     """Run the validate step."""
-    print("[validate] плейсхолдер")
     return 0
 


### PR DESCRIPTION
## Summary
- add logging utility with console and file handlers
- integrate logging into CLI, options and pipeline runner
- document logging behaviour in README

## Testing
- `python scripts/processor.py run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae02c57f108331a314e1171f4e765a