### PR TITLE
feat: enumerate csv sources during collect

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -2,4 +2,13 @@ paths:
   # Directory containing raw DHCP CSV files
   raw_dhcp: data/raw/dhcp
 
+collect:
+  input_dirs:
+    - data/raw/dhcp
+    - data/raw/arm
+    - data/raw/mkp
+    - data/raw/other
+    - data/raw/ubiq
+    - data/raw/siem
+
 

--- a/src/app/ingest/collect.py
+++ b/src/app/ingest/collect.py
@@ -2,8 +2,91 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 
-def run(**kwargs) -> int:
+from app.utils.logging import get_logger
+
+
+DEFAULT_INPUT_DIRS = [
+    "data/raw/dhcp",
+    "data/raw/arm",
+    "data/raw/mkp",
+    "data/raw/other",
+    "data/raw/ubiq",
+    "data/raw/siem",
+]
+
+logger = get_logger(__name__)
+
+
+def _load_input_dirs(config_path: Path) -> list[str]:
+    """Return list of input directories from config or defaults."""
+    dirs: list[str] | None = None
+    if config_path.exists():
+        text = config_path.read_text(encoding="utf-8")
+        try:
+            import yaml  # type: ignore
+
+            data = yaml.safe_load(text) or {}
+            collect = data.get("collect") or {}
+            cfg_dirs = collect.get("input_dirs")
+            if isinstance(cfg_dirs, list):
+                dirs = [str(d) for d in cfg_dirs]
+        except Exception:
+            dirs = None
+        if dirs is None:
+            temp_dirs: list[str] = []
+            in_collect = False
+            in_list = False
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if stripped.startswith("collect:"):
+                    in_collect = True
+                    in_list = False
+                    continue
+                if in_collect and stripped.startswith("input_dirs:"):
+                    in_list = True
+                    continue
+                if in_collect and in_list:
+                    if stripped.startswith("- "):
+                        temp_dirs.append(stripped[2:].strip())
+                    elif not stripped.startswith("#"):
+                        break
+            if temp_dirs:
+                dirs = temp_dirs
+    return dirs or DEFAULT_INPUT_DIRS
+
+
+def run(**kwargs) -> int:  # noqa: D401
     """Run the collect step."""
+    logger.info("▶ step=collect status=start")
+    try:
+        root = Path(__file__).resolve().parents[3]
+        config_path = root / "configs" / "base.yml"
+        input_dirs = _load_input_dirs(config_path)
+        for rel in input_dirs:
+            dir_path = root / rel
+            if not dir_path.is_dir():
+                logger.info("collect: dir not found: %s", rel)
+                continue
+            files = [
+                p.name
+                for p in dir_path.iterdir()
+                if p.is_file()
+                and p.suffix.lower() == ".csv"
+                and not p.name.lower().endswith("example.csv")
+            ]
+            if not files:
+                logger.info("collect: no csv in: %s", rel)
+            else:
+                logger.info(
+                    "collect: files in %s: %s", rel, ", ".join(sorted(files))
+                )
+    except Exception as exc:  # pragma: no cover - minimal error handling
+        logger.error("collect: unexpected error: %s", exc)
+        return 1
+    logger.info("✓ step=collect status=done")
     return 0
 


### PR DESCRIPTION
## Summary
- add collect input directories to base config
- implement collect step to list CSV files from configured directories

## Testing
- `python3 scripts/processor.py run --from collect --to collect`

------
https://chatgpt.com/codex/tasks/task_e_68ae073f5c1c83319ba27b38a223bfa9