### PR TITLE
Уніфіковано логування кроків та статуси

### DIFF
--- a/src/app/ingest/collect.py
+++ b/src/app/ingest/collect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from app.pipeline.status import DONE
 from app.utils.logging import get_logger
 
 
@@ -61,7 +62,6 @@ def _load_input_dirs(config_path: Path) -> list[str]:
 
 def run(**kwargs) -> int:  # noqa: D401
     """Run the collect step."""
-    logger.info("▶ step=collect status=start")
     try:
         root = Path(__file__).resolve().parents[3]
         config_path = root / "configs" / "base.yml"
@@ -87,6 +87,5 @@ def run(**kwargs) -> int:  # noqa: D401
     except Exception as exc:  # pragma: no cover - minimal error handling
         logger.error("collect: unexpected error: %s", exc)
         return 1
-    logger.info("✓ step=collect status=done")
-    return 0
+    return DONE
 

--- a/src/app/pipeline/status.py
+++ b/src/app/pipeline/status.py
@@ -1,0 +1,10 @@
+"""Common status codes for pipeline steps."""
+
+from __future__ import annotations
+
+# Successful completion of a step
+DONE = 0
+
+# Step intentionally skipped / not yet implemented
+SKIPPED = 10
+

--- a/src/app/processors/normalize.py
+++ b/src/app/processors/normalize.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from app.pipeline.status import SKIPPED
+
 
 def run(**kwargs) -> int:
     """Run the normalize step."""
-    return 0
+    return SKIPPED
 

--- a/src/app/quality/checks.py
+++ b/src/app/quality/checks.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from app.pipeline.status import SKIPPED
+
 
 def run(**kwargs) -> int:
     """Run the checks step."""
-    return 0
+    return SKIPPED
 

--- a/src/app/reporters/report.py
+++ b/src/app/reporters/report.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from app.pipeline.status import SKIPPED
+
 
 def run(**kwargs) -> int:
     """Run the report step."""
-    return 0
+    return SKIPPED
 

--- a/src/app/stage/interim.py
+++ b/src/app/stage/interim.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from app.pipeline.status import SKIPPED
+
 
 def run(**kwargs) -> int:
     """Run the interim step."""
-    return 0
+    return SKIPPED
 

--- a/src/app/utils/logging.py
+++ b/src/app/utils/logging.py
@@ -5,16 +5,17 @@ from pathlib import Path
 
 
 def setup_logging(level: str = "INFO", log_file: str = "logs/pscope.log") -> None:
+    root = logging.getLogger()
+    if root.handlers:
+        return
+
     path = Path(log_file)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    root = logging.getLogger()
     root.setLevel(getattr(logging, level.upper(), logging.INFO))
 
     fmt = "[%(asctime)s] %(levelname)s: %(message)s"
     formatter = logging.Formatter(fmt)
-
-    root.handlers.clear()
 
     console = logging.StreamHandler()
     console.setFormatter(formatter)

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from app.pipeline.status import SKIPPED
+
 
 def run(**kwargs) -> int:
     """Run the validate step."""
-    return 0
+    return SKIPPED
 


### PR DESCRIPTION
## Summary
- додано спільні константи DONE/SKIPPED
- runner тепер єдине місце для логів start/done/skipped/error
- порожні кроки повертають SKIPPED
- налаштовано logging.setup_logging без дублювання хендлерів

## Testing
- `python3 scripts/processor.py run`


------
https://chatgpt.com/codex/tasks/task_e_68ae1659dea083319b51f9df50bcdce7