### PR TITLE
refactor: reorder pipeline and centralize csv utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # PrimeScope
 
 ## Пайплайн (структура кроків)
-1. **collect** — відкриття сирих файлів з каталогу `raw`.
-2. **validate** — базова перевірка вмісту.
+1. **validate** — базова перевірка вмісту.
+2. **collect** — відкриття сирих файлів з каталогу `raw`.
 3. **normalize** — приведення даних до уніфікованого вигляду.
 4. **interim** — формування проміжних артефактів.
 5. **checks** — додаткові "ручні" перевірки.
 6. **report** — підготовка фінальних звітів.
+
+Кроки `validate` і `collect` використовують утиліти роботи з CSV з
+`src/app/collectors/files.py`.
 
 ## Запуск
 ```bash
@@ -17,7 +20,7 @@ python scripts/processor.py run       # повний цикл з новими к
 ## CLI: опція run
 
 ### Призначення
-Запуск повного циклу: `collect → validate → normalize → interim → checks → report`.
+Запуск повного циклу: `validate → collect → normalize → interim → checks → report`.
 
 ### Використання
 ```bash
@@ -26,7 +29,7 @@ python scripts/processor.py run [опції]
 ```
 
 ### Прапорці
-- `--from STEP` — почати з кроку (допустимо: `collect|validate|normalize|interim|checks|report`)
+- `--from STEP` — почати з кроку (допустимо: `validate|collect|normalize|interim|checks|report`)
 - `--to STEP` — закінчити на кроці
 - `--skip STEP[,STEP]` — пропустити вказані кроки
 - `--dry-run` — лише показати план без запису файлів
@@ -64,17 +67,17 @@ python scripts/processor.py run [опції]
   ```
 
 ### Допустимі кроки
-`collect`, `validate`, `normalize`, `interim`, `checks`, `report`.
+`validate`, `collect`, `normalize`, `interim`, `checks`, `report`.
 
 ## Логування
 За замовчуванням повідомлення рівня INFO виводяться у консоль та у файл `logs/pscope.log`.
 
 Приклад виводу під час `run`:
 ```
-▶ step=collect status=start
-✓ step=collect status=done duration=0.241s
 ▶ step=validate status=start
 ✓ step=validate status=done duration=0.102s
+▶ step=collect status=start
+✓ step=collect status=done duration=0.241s
 ...
 run: done
 ```

--- a/src/app/collectors/files.py
+++ b/src/app/collectors/files.py
@@ -1,0 +1,58 @@
+"""Utilities for working with CSV files.
+
+This module centralises file-handling helpers shared across steps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+from typing import Iterator, Iterable
+
+
+def list_csv_in_dir(
+    dir_path: str,
+    ignore_suffixes: list[str] | None = None,
+    recursive: bool = False,
+) -> list[str]:
+    """Return sorted list of CSV file paths within *dir_path*.
+
+    Files whose names end with any suffix in *ignore_suffixes* are skipped.
+    When *recursive* is True, the search descends into subdirectories.
+    """
+
+    if ignore_suffixes is None:
+        ignore_suffixes = ["example.csv"]
+
+    base = Path(dir_path)
+    if recursive:
+        paths: Iterable[Path] = base.rglob("*.csv")
+    else:
+        paths = base.glob("*.csv")
+
+    result: list[str] = []
+    for p in paths:
+        name = p.name.lower()
+        if any(name.endswith(s.lower()) for s in ignore_suffixes):
+            continue
+        if p.is_file():
+            result.append(str(p))
+    return sorted(result)
+
+
+def read_headers(path: str) -> list[str]:
+    """Return list of header names from CSV file at *path*."""
+
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        return next(reader, [])
+
+
+def open_csv_rows(path: str) -> Iterator[list[str]]:
+    """Yield rows from CSV file at *path* (excluding the header)."""
+
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        next(reader, None)  # skip header
+        for row in reader:
+            yield row

--- a/src/app/ingest/collect.py
+++ b/src/app/ingest/collect.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from app.pipeline.status import DONE
 from app.utils.logging import get_logger
+from app.collectors.files import list_csv_in_dir
 
 
 DEFAULT_INPUT_DIRS = [
@@ -71,18 +72,13 @@ def run(**kwargs) -> int:  # noqa: D401
             if not dir_path.is_dir():
                 logger.info("collect: dir not found: %s", rel)
                 continue
-            files = [
-                p.name
-                for p in dir_path.iterdir()
-                if p.is_file()
-                and p.suffix.lower() == ".csv"
-                and not p.name.lower().endswith("example.csv")
-            ]
+            files = list_csv_in_dir(str(dir_path))
             if not files:
                 logger.info("collect: no csv in: %s", rel)
             else:
+                names = [Path(p).name for p in files]
                 logger.info(
-                    "collect: files in %s: %s", rel, ", ".join(sorted(files))
+                    "collect: files in %s: %s", rel, ", ".join(sorted(names))
                 )
     except Exception as exc:  # pragma: no cover - minimal error handling
         logger.error("collect: unexpected error: %s", exc)

--- a/src/app/options/options.py
+++ b/src/app/options/options.py
@@ -71,15 +71,24 @@ def get_options() -> Dict[str, Dict[str, object]]:
         }
     if "run" not in _OPTIONS:
         _OPTIONS["run"] = {
-            "about": "Запускає повний цикл: collect → validate → normalize → interim → checks → report",
+            "about": "Запускає повний цикл: validate → collect → normalize → interim → checks → report",
             "usage": "python scripts/processor.py run [опції]",
             "flags": [
-                ("--from STEP", "почати з кроку (collect|validate|normalize|interim|checks|report)"),
+                (
+                    "--from STEP",
+                    "почати з кроку (validate|collect|normalize|interim|checks|report)",
+                ),
                 ("--to STEP", "закінчити на кроці"),
                 ("--skip STEP[,STEP]", "пропустити вказані кроки"),
                 ("--dry-run", "лише показати план без запису файлів"),
-                ("--clean-first", "очистити data/interim перед запуском (окрім *.example.csv)"),
-                ("--yes", "автоматично підтверджувати потенційно руйнівні дії (для --clean-first)"),
+                (
+                    "--clean-first",
+                    "очистити data/interim перед запуском (окрім *.example.csv)",
+                ),
+                (
+                    "--yes",
+                    "автоматично підтверджувати потенційно руйнівні дії (для --clean-first)",
+                ),
             ],
             "examples": [
                 ("Повний цикл", "python3 scripts/processor.py run"),

--- a/src/app/pipeline/flows.py
+++ b/src/app/pipeline/flows.py
@@ -2,8 +2,8 @@
 
 # Default pipeline sequence.
 DEFAULT_FLOW = [
-    "collect",
     "validate",
+    "collect",
     "normalize",
     "interim",
     "checks",

--- a/src/app/pipeline/runner.py
+++ b/src/app/pipeline/runner.py
@@ -11,8 +11,8 @@ from app.utils.logging import get_logger
 
 
 MODULES: Dict[str, str] = {
-    "collect": "app.ingest.collect",
     "validate": "app.validate.validate",
+    "collect": "app.ingest.collect",
     "normalize": "app.processors.normalize",
     "interim": "app.stage.interim",
     "checks": "app.quality.checks",

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -2,10 +2,32 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from app.pipeline.status import SKIPPED
+from app.utils.logging import get_logger
+from app.collectors.files import list_csv_in_dir, read_headers
+
+
+logger = get_logger(__name__)
 
 
 def run(**kwargs) -> int:
     """Run the validate step."""
+    try:
+        root = Path(__file__).resolve().parents[3]
+        raw_dir = root / "data" / "raw"
+        files = list_csv_in_dir(str(raw_dir), recursive=True)
+        if not files:
+            logger.info("validate: no csv found")
+        else:
+            for path in files:
+                headers = read_headers(path)
+                logger.info(
+                    "validate: %s headers: %s", Path(path).name, ", ".join(headers)
+                )
+    except Exception as exc:  # pragma: no cover - minimal error handling
+        logger.error("validate: unexpected error: %s", exc)
+        return 1
     return SKIPPED
 


### PR DESCRIPTION
## Summary
- place `validate` before `collect` in default pipeline flow
- share CSV helpers through new `collectors.files` module
- adjust logging, CLI help and docs for new sequence

## Testing
- `python3 -m pytest`
- `python3 scripts/processor.py run`

------
https://chatgpt.com/codex/tasks/task_e_68af092b681c8331a8b325db6742d09b