### PR TITLE
feat: implement validation step

### DIFF
--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -3,79 +3,210 @@
 from __future__ import annotations
 
 from pathlib import Path
+import ipaddress
+import re
 
 from app.pipeline.status import DONE
 from app.utils.logging import get_logger
-from app.collectors.files import list_csv_in_dir, read_headers
+from app.collectors.files import (
+    list_csv_in_dir,
+    read_headers,
+    open_csv_rows,
+)
 
 
 logger = get_logger(__name__)
 
 
-def _load_dataset_dirs(config_path: Path) -> list[str]:
-    """Return dataset directories from *schemas.yml* config."""
+def _simple_yaml_parse(text: str) -> dict:
+    """Very small YAML subset parser used when PyYAML is unavailable."""
 
-    dirs: list[str] | None = None
-    if config_path.exists():
-        text = config_path.read_text(encoding="utf-8")
+    import ast
+
+    root: dict = {}
+    stack: list[tuple[int, dict]] = [(0, root)]
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        level = indent // 2
+        line = raw_line.strip()
+        if ":" not in line:
+            continue
+        key, value_part = line.split(":", 1)
+        key = key.strip()
+        value_part = value_part.strip()
+        if value_part and not (
+            (value_part.startswith('"') and value_part.endswith('"'))
+            or (value_part.startswith("'") and value_part.endswith("'"))
+        ):
+            if "#" in value_part:
+                value_part = value_part.split("#", 1)[0].strip()
+
+        while stack and stack[-1][0] >= level + 1:
+            stack.pop()
+        current = stack[-1][1]
+
+        if not value_part:
+            new_dict: dict = {}
+            current[key] = new_dict
+            stack.append((level + 1, new_dict))
+            continue
+
+        if value_part.startswith("{") or value_part.startswith("["):
+            try:
+                value = ast.literal_eval(value_part)
+            except Exception:
+                value = {}
+        elif value_part in {"true", "false"}:
+            value = value_part == "true"
+        elif (value_part.startswith('"') and value_part.endswith('"')) or (
+            value_part.startswith("'") and value_part.endswith("'")
+        ):
+            value = value_part[1:-1]
+        else:
+            try:
+                value = ast.literal_eval(value_part)
+            except Exception:
+                value = value_part
+
+        current[key] = value
+
+    return root
+
+
+def _build_normalizer(settings: dict):
+    remove_bom = settings.get("remove_bom", False)
+    trim = settings.get("trim", False)
+    collapse = settings.get("collapse_spaces", False)
+    casefold = settings.get("casefold", False)
+
+    def normalize(value: str, *, is_first: bool = False) -> str:
+        if is_first and remove_bom and value.startswith("\ufeff"):
+            value = value.lstrip("\ufeff")
+        if trim:
+            value = value.strip()
+        if collapse:
+            value = " ".join(value.split())
+        if casefold:
+            value = value.casefold()
+        return value
+
+    return normalize
+
+
+def _apply_rule(
+    value: str,
+    rule: dict,
+    required: bool,
+    canonical: str,
+    rule_name: str,
+) -> str | None:
+    """Validate *value* against *rule* and return error code or None."""
+
+    kind = rule.get("kind", "any")
+    text = value.strip()
+
+    if kind == "any":
+        return None
+
+    if kind == "ip":
+        if not text:
+            return f"empty_value:{canonical}" if required else None
         try:
-            import yaml  # type: ignore
+            ip_obj = ipaddress.ip_address(text)
+        except ValueError:
+            return "invalid_ip"
+        version = rule.get("version", "any")
+        if version == "v4" and ip_obj.version != 4:
+            return "invalid_ip"
+        if version == "v6" and ip_obj.version != 6:
+            return "invalid_ip"
+        return None
 
-            data = yaml.safe_load(text) or {}
-            validate = data.get("validate") or {}
-            datasets = validate.get("datasets") or {}
-            temp: list[str] = []
-            for info in datasets.values():
-                rel = info.get("dir")
-                if isinstance(rel, str):
-                    temp.append(rel)
-            dirs = temp
-        except Exception:
-            dirs = None
-        if dirs is None:
-            temp_dirs: list[str] = []
-            in_validate = False
-            in_datasets = False
-            for line in text.splitlines():
-                stripped = line.strip()
-                if not stripped or stripped.startswith("#"):
-                    continue
-                if stripped.startswith("validate:"):
-                    in_validate = True
-                    in_datasets = False
-                    continue
-                if in_validate and stripped.startswith("datasets:"):
-                    in_datasets = True
-                    continue
-                if in_validate and in_datasets and stripped.startswith("dir:"):
-                    val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
-                    temp_dirs.append(val)
-            if temp_dirs:
-                dirs = temp_dirs
-    return dirs or []
+    if kind == "mac":
+        if not text:
+            return f"empty_value:{canonical}" if required else None
+        cleaned = text.replace(":", "").replace("-", "")
+        if len(cleaned) != 12:
+            return "invalid_mac"
+        try:
+            int(cleaned, 16)
+        except ValueError:
+            return "invalid_mac"
+        return None
+
+    if kind == "nonempty":
+        if not text:
+            return f"empty_value:{canonical}"
+        return None
+
+    if kind == "regex":
+        if not text:
+            return f"empty_value:{canonical}" if required else None
+        pattern = rule.get("_compiled")
+        if pattern and not pattern.fullmatch(text):
+            return f"invalid_{rule_name}"
+        return None
+
+    return None
 
 
 def run(**kwargs) -> int:
     """Run the validate step."""
+
     try:
         root = Path(__file__).resolve().parents[3]
-
-        # --- CSV inventory ---
         config_path = root / "configs" / "schemas.yml"
         if not config_path.exists():
             logger.error("validate: відсутній configs/schemas.yml")
             return 1
 
-        dirs = _load_dataset_dirs(config_path)
-        if not dirs:
-            logger.error("validate: відсутній блок validate.datasets у configs/schemas.yml")
+        text = config_path.read_text(encoding="utf-8")
+        try:  # prefer PyYAML when available
+            import yaml  # type: ignore
+
+            config = yaml.safe_load(text) or {}
+        except Exception:
+            config = _simple_yaml_parse(text)
+        validate_cfg = config.get("validate") or {}
+        settings = validate_cfg.get("settings") or {}
+        rules_cfg = validate_cfg.get("rules") or {}
+        datasets_cfg = validate_cfg.get("datasets") or {}
+
+        if not datasets_cfg:
+            logger.error(
+                "validate: відсутній блок validate.datasets у configs/schemas.yml"
+            )
             return 1
 
-        for rel in dirs:
+        normalize = _build_normalizer(settings.get("normalize_headers", {}))
+        ignore_suffixes = settings.get("ignore_suffixes", ["example.csv"])
+
+        # prepare rules (compile regexes)
+        rules: dict[str, dict] = {}
+        for name, info in rules_cfg.items():
+            info = info or {}
+            if info.get("kind") == "regex":
+                pattern = info.get("pattern")
+                try:
+                    info["_compiled"] = re.compile(pattern) if pattern else None
+                except re.error:
+                    info["_compiled"] = None
+            rules[name] = info
+
+        # --- inventory ---
+        dataset_files: dict[str, list[str]] = {}
+        for ds_name, ds in datasets_cfg.items():
+            rel = ds.get("dir")
+            if not isinstance(rel, str):
+                continue
             dir_path = root / rel
             files = list_csv_in_dir(
-                str(dir_path), ignore_suffixes=["example.csv"], recursive=False
+                str(dir_path), ignore_suffixes=ignore_suffixes, recursive=False
             )
+            dataset_files[ds_name] = files
             if not files:
                 logger.info("validate: no csv in: %s", rel)
             else:
@@ -84,16 +215,103 @@ def run(**kwargs) -> int:
                     "validate: files in %s: %s", rel, ", ".join(sorted(names))
                 )
 
-        # --- Existing header/content checks ---
-        raw_dir = root / "data" / "raw"
-        files = list_csv_in_dir(str(raw_dir), recursive=True)
-        for path in files:
-            headers = read_headers(path)
-            logger.info(
-                "validate: %s headers: %s", Path(path).name, ", ".join(headers)
-            )
+        missing_msgs: list[str] = []
+        content_msgs: list[str] = []
+        files_with_missing: set[str] = set()
+        files_with_content: set[str] = set()
+
+        for ds_name, ds in datasets_cfg.items():
+            fields_cfg = ds.get("fields") or {}
+            if not fields_cfg:
+                logger.info("validate: skipped dataset %s: no schema", ds_name)
+                continue
+
+            files = dataset_files.get(ds_name, [])
+            if not files:
+                continue
+
+            field_defs = {}
+            alias_map: dict[str, str] = {}
+            for canonical, info in fields_cfg.items():
+                aliases_raw = info.get("headers") or []
+                aliases_norm = [normalize(h) for h in aliases_raw]
+                field_defs[canonical] = {
+                    "aliases": aliases_norm,
+                    "aliases_raw": aliases_raw,
+                    "required": bool(info.get("required")),
+                    "check": info.get("check", "any"),
+                }
+                for a in aliases_norm:
+                    if a not in alias_map:
+                        alias_map[a] = canonical
+
+            for path in files:
+                rel_path = str(Path(path).relative_to(root))
+                headers = read_headers(path)
+                norm_headers = [normalize(h, is_first=i == 0) for i, h in enumerate(headers)]
+                found: dict[str, tuple[str, int]] = {}
+                for idx, nh in enumerate(norm_headers):
+                    canonical = alias_map.get(nh)
+                    if canonical and canonical not in found:
+                        found[canonical] = (headers[idx], idx)
+
+                missing_fields: list[str] = []
+                for canonical, info in field_defs.items():
+                    if info["required"] and canonical not in found:
+                        aliases = "|".join(info["aliases_raw"])
+                        missing_fields.append(f"{canonical}[aliases={aliases}]")
+
+                if missing_fields:
+                    msg = (
+                        f"validate: missing required in {rel_path}: "
+                        f"{', '.join(missing_fields)}"
+                    )
+                    logger.error(msg)
+                    missing_msgs.append(msg)
+                    files_with_missing.add(rel_path)
+                else:
+                    logger.info("validate: headers ok: %s", rel_path)
+
+                file_has_error = False
+                if found:
+                    for row_idx, row in enumerate(open_csv_rows(path), start=1):
+                        for canonical, (real_header, col_idx) in found.items():
+                            value = row[col_idx] if col_idx < len(row) else ""
+                            info = field_defs[canonical]
+                            rule_name = info["check"]
+                            rule = rules.get(rule_name, {"kind": "any"})
+                            err = _apply_rule(
+                                value, rule, info["required"], canonical, rule_name
+                            )
+                            if err:
+                                file_has_error = True
+                                msg = (
+                                    f"validate: content error: {rel_path} @row={row_idx} "
+                                    f"field={canonical} code={err} value=\"{value}\""
+                                )
+                                logger.error(msg)
+                                content_msgs.append(msg)
+                                files_with_content.add(rel_path)
+
+                if not file_has_error:
+                    logger.info("validate: content ok: %s", rel_path)
+
+        total_issues = len(missing_msgs) + len(content_msgs)
+        logger.info(
+            "validate: errors summary: files_with_missing=%d, files_with_content_errors=%d, total_issues=%d",
+            len(files_with_missing),
+            len(files_with_content),
+            total_issues,
+        )
+
+        exit_code = DONE
+        if (
+            settings.get("stop_on_missing_required", True) and missing_msgs
+        ) or (settings.get("stop_on_content_error", True) and content_msgs):
+            exit_code = 1
+        return exit_code
+
     except Exception as exc:  # pragma: no cover - minimal error handling
         logger.error("validate: unexpected error: %s", exc)
         return 1
-    return DONE
 


### PR DESCRIPTION
## Summary
- implement complete validation step with YAML config support
- normalize headers and validate content per rules
- accumulate and report validation errors with summary and exit codes

## Testing
- `pytest`
- `PYTHONPATH=src python - <<'PY'
from app.utils.logging import setup_logging
from app.validate import validate
setup_logging()
validate.run()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af17fcc4ec83319c3d1f7476af960d