### PR TITLE
Allow dash literal for random MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ python scripts/processor.py run [опції]
 ### Допустимі кроки
 `validate`, `collect`, `normalize`, `interim`, `checks`, `report`.
 
+## validate.rules
+У `configs/schemas.yml` перелічені правила для кроку `validate`. Кожне правило
+може мати параметр `allow_literals` — список значень, які приймаються без
+перевірки формату. Наприклад, правило `mac_or_dash` дозволяє рядок `'-'` у
+полі з MAC-адресою:
+
+```yaml
+validate:
+  rules:
+    mac_or_dash:
+      kind: mac
+      allow_literals: ["-"]
+  datasets:
+    arm:
+      fields:
+        randmac:
+          headers: ["Random MAC","randmac","dynamic_mac"]
+          check: mac_or_dash
+          required: false
+    mkp:
+      fields:
+        randmac:
+          headers: ["Динамічний MAC","Dynamic MAC","randmac"]
+          check: mac_or_dash
+          required: false
+```
+
 ## Логування
 За замовчуванням повідомлення рівня INFO виводяться у консоль та у файл `logs/pscope.log`.
 

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -18,6 +18,9 @@ validate:
       version: any    # any | v4 | v6
     mac:
       kind: mac       # приймаємо : або - або без розділювачів; регістр неважливий
+    mac_or_dash:
+      kind: mac
+      allow_literals: ["-"]
     nonempty:
       kind: nonempty  # не порожнє значення
     hostname:
@@ -53,8 +56,8 @@ validate:
           check: ip
           required: true
         randmac:
-          headers: ["Random MAC", "randomMac"]
-          check: mac
+          headers: ["Random MAC", "randmac", "dynamic_mac"]
+          check: mac_or_dash
           required: false
         ownership:
           headers: ["Власність", "ownership"]
@@ -82,7 +85,7 @@ validate:
           required: true
         randmac:
           headers: ["Динамічний MAC", "Dynamic MAC", "randmac"]
-          check: mac
+          check: mac_or_dash
           required: false
         category:
           headers: ["Категорія МКП", "category"]

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -128,6 +128,9 @@ def _apply_rule(
     if kind == "mac":
         if not text:
             return f"empty_value:{canonical}" if required else None
+        allowed = set(rule.get("allow_literals", []) or [])
+        if text in allowed:
+            return None
         cleaned = text.replace(":", "").replace("-", "")
         if len(cleaned) != 12:
             return "invalid_mac"


### PR DESCRIPTION
## Summary
- support `allow_literals` for MAC validation
- add `mac_or_dash` rule and apply to `arm`/`mkp` `randmac`
- document `allow_literals` in README

## Testing
- `python scripts/processor.py run --from validate --to validate`


------
https://chatgpt.com/codex/tasks/task_e_68af397e426483318a6429ddac64f1eb