### PR TITLE
Allow literals in MAC validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,27 +73,27 @@ python scripts/processor.py run [опції]
 ## validate.rules
 У `configs/schemas.yml` перелічені правила для кроку `validate`. Кожне правило
 може мати параметр `allow_literals` — список значень, які приймаються без
-перевірки формату. Наприклад, правило `mac_or_dash` дозволяє рядок `'-'` у
-полі з MAC-адресою:
+перевірки формату. Наприклад, правило `mac_or_literals` дозволяє рядки `'-'` та
+`'N/A'` у полі з MAC-адресою:
 
 ```yaml
 validate:
   rules:
-    mac_or_dash:
+    mac_or_literals:
       kind: mac
-      allow_literals: ["-"]
+      allow_literals: ["-", "N/A"]
   datasets:
     arm:
       fields:
         randmac:
           headers: ["Random MAC","randmac","dynamic_mac"]
-          check: mac_or_dash
+          check: mac_or_literals
           required: false
     mkp:
       fields:
         randmac:
           headers: ["Динамічний MAC","Dynamic MAC","randmac"]
-          check: mac_or_dash
+          check: mac_or_literals
           required: false
 ```
 

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -18,7 +18,7 @@ validate:
       version: any    # any | v4 | v6
     mac:
       kind: mac       # приймаємо : або - або без розділювачів; регістр неважливий
-    mac_or_dash:
+    mac_or_literals:
       kind: mac
       allow_literals: ["-", "N/A"]
     nonempty:
@@ -37,7 +37,7 @@ validate:
       fields:
         mac:
           headers: ["Static MAC", "mac", "staticMac"]
-          check: mac_or_dash
+          check: mac_or_literals
           required: true
         hostname:
           headers: ["Hostname"]
@@ -57,7 +57,7 @@ validate:
           required: true
         randmac:
           headers: ["Random MAC", "randmac", "dynamic_mac"]
-          check: mac_or_dash
+          check: mac_or_literals
           required: false
         ownership:
           headers: ["Власність", "ownership"]
@@ -85,7 +85,7 @@ validate:
           required: true
         randmac:
           headers: ["Динамічний MAC", "Dynamic MAC", "randmac"]
-          check: mac_or_dash
+          check: mac_or_literals
           required: false
         category:
           headers: ["Категорія МКП", "category"]

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -128,7 +128,8 @@ def _apply_rule(
     if kind == "mac":
         if not text:
             return f"empty_value:{canonical}" if required else None
-        allowed = set(rule.get("allow_literals", []) or [])
+        # allow_literals: special placeholders that bypass format validation
+        allowed = set(rule.get("allow_literals") or [])
         if text in allowed:
             return None
         cleaned = text.replace(":", "").replace("-", "")


### PR DESCRIPTION
## Summary
- add mac_or_literals rule allowing `-` or `N/A`
- handle allowed literals in MAC validator
- document mac_or_literals rule and update randmac schema

## Testing
- `pytest`
- `python scripts/processor.py run --from validate --to validate`


------
https://chatgpt.com/codex/tasks/task_e_68af3e5247d48331ab0023087e73f809