### PR TITLE
feat: allow service literals for IP fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,32 @@ python scripts/processor.py run [опції]
 ## validate.rules
 У `configs/schemas.yml` перелічені правила для кроку `validate`. Кожне правило
 може мати параметр `allow_literals` — список значень, які приймаються без
-перевірки формату. Наприклад, правило `mac_or_literals` дозволяє рядки `'-'` та
-`'N/A'` у полі з MAC-адресою:
+перевірки формату. Наприклад, правило `ip_or_literals` дозволяє рядок
+`"N/A"` у полі з IP-адресою:
 
 ```yaml
 validate:
   rules:
-    mac_or_literals:
-      kind: mac
-      allow_literals: ["-", "N/A"]
+    ip_or_literals:
+      kind: ip
+      version: any
+      allow_literals: ["N/A"]
   datasets:
     arm:
       fields:
-        randmac:
-          headers: ["Random MAC","randmac","dynamic_mac"]
-          check: mac_or_literals
-          required: false
+        ip:
+          headers: ["IP","ip_address","ip-address"]
+          check: ip_or_literals
+          required: true
     mkp:
       fields:
-        randmac:
-          headers: ["Динамічний MAC","Dynamic MAC","randmac"]
-          check: mac_or_literals
+        ip:
+          headers: ["IP","ip_address","ip-address"]
+          check: ip_or_literals
           required: false
 ```
+
+Аналогічний підхід використовується для MAC через правило `mac_or_literals`.
 
 ## Логування
 За замовчуванням повідомлення рівня INFO виводяться у консоль та у файл `logs/pscope.log`.

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -16,6 +16,10 @@ validate:
     ip:
       kind: ip        # ipv4/ipv6/any — за замовч., дозволити будь-який
       version: any    # any | v4 | v6
+    ip_or_literals:
+      kind: ip
+      version: any         # any | v4 | v6 — за потреби можна звузити
+      allow_literals: ["N/A"]   # точні значення, що приймаються без IP-перевірки
     mac:
       kind: mac       # приймаємо : або - або без розділювачів; регістр неважливий
     mac_or_literals:
@@ -53,7 +57,7 @@ validate:
           required: true
         ip:
           headers: ["IP", "ip_address", "ip-address"]
-          check: ip
+          check: ip_or_literals
           required: true
         randmac:
           headers: ["Random MAC", "randmac", "dynamic_mac"]
@@ -93,7 +97,7 @@ validate:
           required: true
         ip:
           headers: ["IP", "ip_address", "ip-address"]
-          check: ip
+          check: ip_or_literals
           required: false  # якщо в MKP IP не завжди є — залишити false
 
     siem:

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -114,6 +114,10 @@ def _apply_rule(
     if kind == "ip":
         if not text:
             return f"empty_value:{canonical}" if required else None
+        # allow_literals: special placeholders that bypass IP validation
+        allowed = set(rule.get("allow_literals") or [])
+        if text in allowed:
+            return None
         try:
             ip_obj = ipaddress.ip_address(text)
         except ValueError:


### PR DESCRIPTION
## Summary
- allow `ip` validator to accept specified placeholder literals
- add `ip_or_literals` rule with default `"N/A"` placeholder
- document IP literal handling in README and schemas

## Testing
- `python scripts/processor.py run --from validate --to validate`


------
https://chatgpt.com/codex/tasks/task_e_68af401653f88331b53a476243b5625b