### PR TITLE
feat: detect confusable symbols in mac validation

### DIFF
--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -10,7 +10,29 @@ validate:
       remove_bom: true                # прибрати BOM з першого заголовка
     stop_on_missing_required: true    # якщо бракує обов'язкових колонок — зупиняти пайплайн
     stop_on_content_error: true       # якщо вміст не проходить валідацію (наприклад, не-IP) — зупиняти
+    detect_confusables: true          # виявляти «схожі» символи у значеннях
 
+  confusables_map:
+    А: "A"    # U+0410 CYRILLIC CAPITAL A
+    а: "a"    # U+0430
+    В: "B"    # U+0412
+    Е: "E"    # U+0415
+    е: "e"    # U+0435
+    О: "O"    # U+041E
+    о: "o"    # U+043E
+    Р: "P"    # U+0420
+    р: "p"    # U+0440
+    С: "C"    # U+0421
+    с: "c"    # U+0441
+    Т: "T"    # U+0422
+    Х: "X"    # U+0425
+    х: "x"    # U+0445
+    ‐: "-"    # U+2010 HYPHEN
+    ‑: "-"    # U+2011 NON-BREAKING HYPHEN
+    –: "-"    # U+2013 EN DASH
+    —: "-"    # U+2014 EM DASH
+    ：: ":"    # U+FF1A FULLWIDTH COLON
+    ﹕: ":"    # U+FE55 SMALL COLON
   # Набір валідаторів, які можна призначати полям
   rules:
     ip:


### PR DESCRIPTION
## Summary
- detect confusable non-ASCII characters in MAC fields and suggest ASCII replacements
- add optional `detect_confusables` setting and static `confusables_map`
- report files with confusable characters separately in validation summary

## Testing
- `python scripts/processor.py run --from validate --to validate` (with a CSV containing `72:с1:5с:90:71:bf`)


------
https://chatgpt.com/codex/tasks/task_e_68af44a25090833198130c0871f68584