### PR TITLE
feat: enforce required raw csv presence

### DIFF
--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -3,6 +3,7 @@ validate:
   settings:
     file_glob: "*.csv"                # маска файлів у каталозі
     ignore_suffixes: ["example.csv"]  # ігнорувати файли, що закінчуються на example.csv
+    required_datasets: ["siem", "dhcp", "ubiq"]  # обов'язкові джерела для інвентаризації
     normalize_headers:                # як зрівнювати заголовки
       casefold: true                  # нечутливість до регістру
       trim: true                      # обрізати пробіли по краях

--- a/src/app/validate/validate.py
+++ b/src/app/validate/validate.py
@@ -193,6 +193,7 @@ def run(**kwargs) -> int:
 
         normalize = _build_normalizer(settings.get("normalize_headers", {}))
         ignore_suffixes = settings.get("ignore_suffixes", ["example.csv"])
+        required_datasets = settings.get("required_datasets") or ["siem", "dhcp", "ubiq"]
 
         # prepare rules (compile regexes)
         rules: dict[str, dict] = {}
@@ -208,6 +209,7 @@ def run(**kwargs) -> int:
 
         # --- inventory ---
         dataset_files: dict[str, list[str]] = {}
+        missing_required: list[str] = []
         for ds_name, ds in datasets_cfg.items():
             rel = ds.get("dir")
             if not isinstance(rel, str):
@@ -217,13 +219,28 @@ def run(**kwargs) -> int:
                 str(dir_path), ignore_suffixes=ignore_suffixes, recursive=False
             )
             dataset_files[ds_name] = files
-            if not files:
-                logger.info("validate: no csv in: %s", rel)
-            else:
+            if files:
                 names = [Path(p).name for p in files]
                 logger.info(
                     "validate: files in %s: %s", rel, ", ".join(sorted(names))
                 )
+            else:
+                if ds_name in required_datasets:
+                    logger.error(
+                        "validate: required csv missing in %s (dataset=%s): need at least one *.csv (excluding *example.csv)",
+                        rel,
+                        ds_name,
+                    )
+                    missing_required.append(ds_name)
+                else:
+                    logger.info("validate: no csv in: %s", rel)
+
+        if missing_required:
+            logger.error(
+                "validate: errors summary: required_dirs_missing=%d",
+                len(missing_required),
+            )
+            return 1
 
         missing_msgs: list[str] = []
         content_msgs: list[str] = []


### PR DESCRIPTION
## Summary
- require CSV files in siem, dhcp, and ubiq directories before validation
- configure mandatory datasets in `schemas.yml`

## Testing
- `pytest -q`
- `PYTHONPATH=src python - <<'PY'
from app.utils.logging import setup_logging
from app.validate.validate import run
setup_logging(level="INFO")
code = run()
print('exit_code', code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b007cc96f88331ad519c34c8bfa5a7