### PR TITLE
Add cross-directory CSV presence check to validate step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ python scripts/processor.py run [опції]
 ### Допустимі кроки
 `validate`, `collect`, `normalize`, `interim`, `checks`, `report`.
 
+## validate
+На початку кроку `validate` перевіряється наявність хоча б одного CSV-файла
+(окрім `*example.csv`) у директоріях `data/raw/siem`, `data/raw/dhcp`,
+`data/raw/ubiq`. Якщо в усіх трьох директоріях немає жодного такого файлу —
+крок завершується з помилкою, і наступні етапи не запускаються.
+
+Приклади логів:
+
+```text
+# Відсутні файли у всіх директоріях
+▶ step=validate status=start
+validate: no csv in: data/raw/siem
+validate: no csv in: data/raw/dhcp
+validate: no csv in: data/raw/ubiq
+validate: no required csv found across (siem, dhcp, ubiq): need at least one *.csv (excluding *example.csv)
+validate: errors summary: required_any_missing=1
+✖ step=validate status=fail duration=0.01s
+
+# Файли є хоча б в одній директорії
+▶ step=validate status=start
+validate: files in data/raw/siem: logs.csv
+validate: no csv in: data/raw/dhcp
+validate: no csv in: data/raw/ubiq
+validate: errors summary: files_with_confusables=0, files_with_content_errors=0, total_issues=0
+✓ step=validate status=done duration=0.01s
+```
+
 ## validate.rules
 У `configs/schemas.yml` перелічені правила для кроку `validate`. Кожне правило
 може мати параметр `allow_literals` — список значень, які приймаються без

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -3,7 +3,7 @@ validate:
   settings:
     file_glob: "*.csv"                # маска файлів у каталозі
     ignore_suffixes: ["example.csv"]  # ігнорувати файли, що закінчуються на example.csv
-    required_datasets: ["siem", "dhcp", "ubiq"]  # обов'язкові джерела для інвентаризації
+    require_at_least_one_from: ["siem", "dhcp", "ubiq"]  # потрібно хоча б одне джерело
     normalize_headers:                # як зрівнювати заголовки
       casefold: true                  # нечутливість до регістру
       trim: true                      # обрізати пробіли по краях


### PR DESCRIPTION
## Summary
- ensure `validate` step checks that at least one CSV exists across `siem`, `dhcp` or `ubiq`
- skip later validation when none found and report clear error
- document the new behaviour and example logs

## Testing
- `python scripts/processor.py run --from validate --to validate` (no CSVs)
- `python scripts/processor.py run --from validate --to validate` (with sample CSV)
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00b50393c8331afa45dc6d0d3d52d