### PR TITLE
feat: enforce run-step validation and CLI help

### DIFF
--- a/src/app/options/options.py
+++ b/src/app/options/options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 from typing import Dict, List
 
 from app.utils.logging import get_logger
@@ -36,6 +37,11 @@ def _help_handler(args: List[str]) -> int:
             print("\nПрапорці")
             for flag, desc in flags:
                 print(f"  {flag:<24} {desc}")
+        notes = spec.get("notes")
+        if notes:
+            print("")
+            for line in notes:
+                print(line)
         examples = spec.get("examples")
         if examples:
             print("\nПриклади")
@@ -47,16 +53,93 @@ def _help_handler(args: List[str]) -> int:
     return 2
 
 
+class _RunArgumentParser(argparse.ArgumentParser):
+    """Argument parser that raises exceptions instead of exiting."""
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        raise ValueError(message)
+
+
 def _run_handler(args: List[str]) -> int:
     """Handler for the run option."""
-    logger.info("run: start")
-    kwargs = {}
-    for arg in args:
-        if arg.startswith("--") and "=" in arg:
-            key, value = arg[2:].split("=", 1)
-            kwargs[key.replace("-", "_")] = value
+    parser = _RunArgumentParser(prog="run", add_help=False, allow_abbrev=False)
+    parser.add_argument("--from", dest="from_step")
+    parser.add_argument("--to", dest="to_step")
+    parser.add_argument("--skip")
+    parser.add_argument("--only")
+    parser.add_argument("--dry-run", dest="dry_run", action="store_true")
+    parser.add_argument("--clean-first", dest="clean_first", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+
+    try:
+        ns = parser.parse_args(args)
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith("unrecognized arguments: "):
+            arg = msg.split(": ", 1)[1].split()[0]
+            logger.error("run: unexpected argument '%s'", arg)
+            logger.error("Hint: see 'python3 scripts/processor.py help run'")
+        else:
+            logger.error("run: %s", msg)
+            logger.error("Hint: see 'python3 scripts/processor.py help run'")
+        return 2
+
     from app.pipeline import flows, runner
-    code = runner.run_flow(flow=flows.DEFAULT_FLOW, **kwargs)
+
+    steps = flows.STEPS
+
+    # Validate flags
+    skip_steps = [s.strip() for s in ns.skip.split(",") if s.strip()] if ns.skip else []
+
+    if ns.only and (ns.from_step or ns.to_step or ns.skip):
+        logger.error("run: --only is mutually exclusive with --from/--to/--skip")
+        return 2
+
+    errors = []
+    if ns.only and ns.only not in steps:
+        errors.append(("only", ns.only))
+    if ns.from_step and ns.from_step not in steps:
+        errors.append(("from", ns.from_step))
+    if ns.to_step and ns.to_step not in steps:
+        errors.append(("to", ns.to_step))
+    for s in skip_steps:
+        if s not in steps:
+            errors.append(("skip", s))
+
+    if errors:
+        for flag, value in errors:
+            logger.error("run: unknown step '%s' for --%s", value, flag)
+        logger.error("Allowed steps: %s", ", ".join(steps))
+        return 2
+
+    if ns.from_step and ns.to_step:
+        if steps.index(ns.from_step) > steps.index(ns.to_step):
+            order = "→".join(steps)
+            logger.error(
+                "run: invalid range --from %s --to %s (order: %s)",
+                ns.from_step,
+                ns.to_step,
+                order,
+            )
+            return 2
+
+    if ns.only:
+        plan = [ns.only]
+    else:
+        start = steps.index(ns.from_step) if ns.from_step else 0
+        end = steps.index(ns.to_step) + 1 if ns.to_step else len(steps)
+        plan = [s for s in steps[start:end] if s not in skip_steps]
+
+    logger.info("run: start")
+    logger.info("run: plan = %s", ", ".join(plan))
+
+    kwargs = {
+        "dry_run": ns.dry_run,
+        "clean_first": ns.clean_first,
+        "yes": ns.yes,
+    }
+
+    code = runner.run_flow(flow=plan, **kwargs)
     logger.info("run: done")
     return code
 
@@ -70,36 +153,34 @@ def get_options() -> Dict[str, Dict[str, object]]:
             "handler": _help_handler,
         }
     if "run" not in _OPTIONS:
+        from app.pipeline import flows
+
+        allowed_steps = ", ".join(flows.STEPS)
         _OPTIONS["run"] = {
             "about": "Запускає повний цикл: validate → collect → normalize → interim → checks → report",
             "usage": "python scripts/processor.py run [опції]",
             "flags": [
-                (
-                    "--from STEP",
-                    "почати з кроку (validate|collect|normalize|interim|checks|report)",
-                ),
+                ("--from STEP", "почати з кроку"),
                 ("--to STEP", "закінчити на кроці"),
                 ("--skip STEP[,STEP]", "пропустити вказані кроки"),
                 ("--dry-run", "лише показати план без запису файлів"),
-                (
-                    "--clean-first",
-                    "очистити data/interim перед запуском (окрім *.example.csv)",
-                ),
+                ("--clean-first", "очистити data/interim перед запуском (окрім *.example.csv)"),
                 (
                     "--yes",
                     "автоматично підтверджувати потенційно руйнівні дії (для --clean-first)",
                 ),
             ],
+            "notes": [
+                f"Allowed steps: {allowed_steps}",
+                "--only не можна комбінувати з --from/--to/--skip",
+            ],
             "examples": [
                 ("Повний цикл", "python3 scripts/processor.py run"),
                 ("Сухий прогін (без змін на диску)", "python3 scripts/processor.py run --dry-run"),
                 ("Очистити проміжні файли й запустити цикл", "python3 scripts/processor.py run --clean-first --yes"),
-                (
-                    "Запустити частину пайплайну (лише від normalize до report)",
-                    "python3 scripts/processor.py run --from normalize --to report",
-                ),
+                ("Запустити частину пайплайну", "python3 scripts/processor.py run --from collect --to report"),
                 ("Пропустити додаткові перевірки", "python3 scripts/processor.py run --skip checks"),
-                ("Запустити тільки один крок (лише collect)", "python3 scripts/processor.py run --from collect --to collect"),
+                ("Запустити тільки один крок (лише collect)", "python3 scripts/processor.py run --only collect"),
                 ("Пропустити кілька кроків", "python3 scripts/processor.py run --skip normalize,checks"),
             ],
             "handler": _run_handler,

--- a/src/app/pipeline/flows.py
+++ b/src/app/pipeline/flows.py
@@ -1,7 +1,7 @@
 """Definitions of processing flows for PrimeScope."""
 
-# Default pipeline sequence.
-DEFAULT_FLOW = [
+# Canonical list of processing steps used across the project.
+STEPS = [
     "validate",
     "collect",
     "normalize",
@@ -9,6 +9,9 @@ DEFAULT_FLOW = [
     "checks",
     "report",
 ]
+
+# Default pipeline sequence simply includes all known steps.
+DEFAULT_FLOW = list(STEPS)
 
 # Placeholder for future custom flows.
 EXAMPLE_FLOW = DEFAULT_FLOW


### PR DESCRIPTION
## Summary
- centralize pipeline steps in `flows.STEPS`
- add strict argument parsing and plan selection for `run`
- document allowed steps and flag rules in help

## Testing
- `python3 scripts/processor.py run www; echo $?`
- `python3 scripts/processor.py run --only collect`
- `python3 scripts/processor.py run --from second --to finish`
- `python -m pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b0192664f88331b417337ab799e0c8