### PR TITLE
feat: add dataset roles and early primary check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,30 +71,25 @@ python scripts/processor.py run [опції]
 `validate`, `collect`, `normalize`, `interim`, `checks`, `report`.
 
 ## validate
+Ролі джерел задаються у `configs/schemas.yml` → `validate.settings.roles`.
 На початку кроку `validate` перевіряється наявність хоча б одного CSV-файла
-(окрім `*example.csv`) у директоріях `data/raw/siem`, `data/raw/dhcp`,
-`data/raw/ubiq`. Якщо в усіх трьох директоріях немає жодного такого файлу —
-крок завершується з помилкою, і наступні етапи не запускаються.
+(окрім `*example.csv`) серед **primary**-датасетів:
+`ubiq`, `dhcp`, `siem`, `owrt`. Якщо у всіх цих директоріях немає жодного
+придатного файлу — крок завершується з помилкою, і наступні етапи не
+запускаються. Джерела з роллю **secondary** (`arm`, `mkp`, `other`) можуть
+відсутні — це не помилка.
 
-Приклади логів:
+Приклад логів при відсутності CSV у всіх primary:
 
 ```text
-# Відсутні файли у всіх директоріях
 ▶ step=validate status=start
-validate: no csv in: data/raw/siem
-validate: no csv in: data/raw/dhcp
 validate: no csv in: data/raw/ubiq
-validate: no required csv found across (siem, dhcp, ubiq): need at least one *.csv (excluding *example.csv)
+validate: no csv in: data/raw/dhcp
+validate: no csv in: data/raw/siem
+validate: no csv in: data/raw/owrt
+validate: no required csv found across primary datasets (ubiq, dhcp, siem, owrt): need at least one *.csv (excluding *example.csv)
 validate: errors summary: required_any_missing=1
 ✖ step=validate status=fail duration=0.01s
-
-# Файли є хоча б в одній директорії
-▶ step=validate status=start
-validate: files in data/raw/siem: logs.csv
-validate: no csv in: data/raw/dhcp
-validate: no csv in: data/raw/ubiq
-validate: errors summary: files_with_confusables=0, files_with_content_errors=0, total_issues=0
-✓ step=validate status=done duration=0.01s
 ```
 
 ## validate.rules

--- a/configs/schemas.yml
+++ b/configs/schemas.yml
@@ -1,9 +1,11 @@
 validate:
   # Загальні правила для парсингу заголовків і файлів
   settings:
+    roles:
+      primary: ["ubiq", "dhcp", "siem", "owrt"]
+      secondary: ["arm", "mkp", "other"]
     file_glob: "*.csv"                # маска файлів у каталозі
     ignore_suffixes: ["example.csv"]  # ігнорувати файли, що закінчуються на example.csv
-    require_at_least_one_from: ["siem", "dhcp", "ubiq"]  # потрібно хоча б одне джерело
     normalize_headers:                # як зрівнювати заголовки
       casefold: true                  # нечутливість до регістру
       trim: true                      # обрізати пробіли по краях
@@ -58,6 +60,38 @@ validate:
 
   # Опис датасетів: прив'язка до директорій і полів
   datasets:
+
+    ubiq:
+      dir: "data/raw/ubiq"
+      fields: { }   # порожньо → skipped
+
+    dhcp:
+      dir: "data/raw/dhcp"
+      fields: { }   # порожньо → skipped
+
+    siem:
+      dir: "data/raw/siem"
+      fields:
+        logSourceIdentifier:
+          headers: ["logSourceIdentifier"]
+          check: ip
+          required: true
+        sourcMACAddress:
+          headers: ["sourcMACAddress"]
+          check: mac
+          required: true
+        payloadAsUTF:
+          headers: ["payloadAsUTF"]
+          check: nonempty
+          required: true
+        deviceTime:
+          headers: ["deviceTime"]
+          check: nonempty
+          required: true
+
+    owrt:
+      dir: "data/raw/owrt"
+      fields: { }   # порожньо → skipped
 
     arm:
       dir: "data/raw/arm"
@@ -123,35 +157,7 @@ validate:
           check: ip_or_literals
           required: false  # якщо в MKP IP не завжди є — залишити false
 
-    siem:
-      dir: "data/raw/siem"
-      fields:
-        logSourceIdentifier:
-          headers: ["logSourceIdentifier"]
-          check: ip
-          required: true
-        sourcMACAddress:
-          headers: ["sourcMACAddress"]
-          check: mac
-          required: true
-        payloadAsUTF:
-          headers: ["payloadAsUTF"]
-          check: nonempty
-          required: true
-        deviceTime:
-          headers: ["deviceTime"]
-          check: nonempty
-          required: true
-
     # Поки що для цих директорій schema відсутня — validate має їх пропускати
     other:
       dir: "data/raw/other"
       fields: { }   # порожньо → крок validate позначає як skipped
-
-    ubiq:
-      dir: "data/raw/ubiq"
-      fields: { }   # порожньо → skipped
-
-    dhcp:
-      dir: "data/raw/dhcp"
-      fields: { }   # порожньо → skipped

--- a/data/raw/owrt/data.example.csv
+++ b/data/raw/owrt/data.example.csv
@@ -1,0 +1,2 @@
+example,header
+value1,value2


### PR DESCRIPTION
## Summary
- define primary/secondary dataset roles in `schemas.yml`
- inventory primary sources early and require at least one CSV
- document new roles and early-stop logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/processor.py run --from validate --to validate` *(fails: no required csv found across primary datasets)*

------
https://chatgpt.com/codex/tasks/task_e_68b05356f1a88331b692b95ddd05d6a0